### PR TITLE
Fix a lot of warnings

### DIFF
--- a/src_pksv/codeproc.c
+++ b/src_pksv/codeproc.c
@@ -33,8 +33,8 @@ unsigned int fail;
 int *basedef2 = NULL;
 char **defnames2 = NULL;
 
-int def_alloc2 = 0;
-int def_size2 = 0;
+size_t def_alloc2 = 0;
+size_t def_size2 = 0;
 
 int codenum = 0;
 int levelnum = 0;
@@ -93,7 +93,7 @@ void Define2(unsigned int otherthing, char *thing) {
 }
 unsigned int fail2;
 char *WhatIs2(int thing) {
-  register int i;
+  register size_t i;
   fail = 0;
   for (i = 0; i < def_size2; i++)
     if (thing == basedef2[i]) return defnames2[i];
@@ -209,7 +209,7 @@ unsigned char gffs;
 uint32_t GenForFunc(char *func, pos_int *ppos, char *Script,
                     struct bsearch_root *defines, codeblock *c) {
   uint32_t result = 0;
-  char buf[1024], log_buf[1024];
+  char buf[1024], log_buf[2048];
   gffs = 0;
   pos_int i = skip_whitespace(Script, *ppos);
 

--- a/src_pksv/decompiler.c
+++ b/src_pksv/decompiler.c
@@ -2294,8 +2294,8 @@ FILE* scrf;
 
 void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
                  char* filename, FILE* fsend) {
-  unsigned int still_going, arg1, arg2, arg3, arg4, arg5, arg6, arg7, endat,
-      failsafe = 0, lastdata, lastdata2;
+  unsigned int still_going = 0, arg1 = 0, arg2 = 0, arg3 = 0, arg4 = 0, arg5 = 0, arg6 = 0, arg7 = 0, endat = 0,
+      failsafe = 0, lastdata = 0, lastdata2 = 0;
   unsigned char command, lastcmd;
   register FILE* fileM = fileM_;
   size_t read;
@@ -6542,8 +6542,7 @@ void DecodeProc(FILE* fileM, unsigned int narc, unsigned int FileZoomPos,
   }
 }
 
-void DecodeProcASM(FILE* fileM, unsigned int FileZoomPos, char* fname,
-                   FILE* fsend) {
+void DecodeProcASM(FILE* fileM, unsigned int FileZoomPos, FILE* fsend) {
   register unsigned int arg1, failsafe;
   unsigned int arg2, arg3;
   char buf[1024];
@@ -6634,7 +6633,7 @@ void DecodeProcASM(FILE* fileM, unsigned int FileZoomPos, char* fname,
   }
 }
 
-void DecodeProcText(FILE* fileM, unsigned int FileZoomPos, char* fname,
+void DecodeProcText(unsigned int FileZoomPos, char* fname,
                     FILE* fsend) {
   initDoneProcs();
   if (dyndec) fprintf(fsend, "#dynamic 0x%X\n", dynplace);
@@ -6662,8 +6661,7 @@ void DecodeProcText(FILE* fileM, unsigned int FileZoomPos, char* fname,
   decompile_single_text(fsend, fname, FileZoomPos);
 }
 
-void DecodeProcPointer(FILE* fileM, unsigned int FileZoomPos, char* fname,
-                       FILE* fsend) {
+void DecodeProcPointer(FILE* fileM, unsigned int FileZoomPos, FILE* fsend) {
   unsigned int arg2;
   initDoneProcs();
   if (dyndec) fprintf(fsend, "#dynamic 0x%X\n", dynplace);
@@ -6702,8 +6700,7 @@ void DecodeProcPointer(FILE* fileM, unsigned int FileZoomPos, char* fname,
   }
 }
 
-void DecodeProcMoves(FILE* fileM, unsigned int FileZoomPos, char* fname,
-                     FILE* fsend) {
+void DecodeProcMoves(unsigned int FileZoomPos, char* fname, FILE* fsend) {
   initDoneProcs();
   if (dyndec) fprintf(fsend, "#dynamic 0x%X\n", dynplace);
   if (VersionOverride) {
@@ -6735,8 +6732,7 @@ void DecodeProcMoves(FILE* fileM, unsigned int FileZoomPos, char* fname,
             transmove(FileZoomPos & 0x07ffffff, fname));
 }
 
-void DecodeProcMart(FILE* fileM, unsigned int FileZoomPos, char* fname,
-                    FILE* fsend) {
+void DecodeProcMart(FILE* fileM, unsigned int FileZoomPos, FILE* fsend) {
   register char* m;
   int arg2;
   initDoneProcs();
@@ -6783,8 +6779,7 @@ void DecodeProcMart(FILE* fileM, unsigned int FileZoomPos, char* fname,
   fprintf(fsend, "\n");
 }
 
-void DecodeProcAttacks(FILE* fileM, unsigned int FileZoomPos, char* fname,
-                       FILE* fsend) {
+void DecodeProcAttacks(FILE* fileM, unsigned int FileZoomPos, FILE* fsend) {
   register char* m;
   int arg2;
   initDoneProcs();

--- a/src_pksv/decompiler.c
+++ b/src_pksv/decompiler.c
@@ -4718,7 +4718,7 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
                                    (arg2 << 8));
             fprintf(fsend, "applymovement 0x%X 0x%X ' 0x%X\n", arg1, arg2,
                     arg3);
-            if (arg3 != -1) DoMove(arg3);
+            if (arg3 != -1U) DoMove(arg3);
             break;
           case GLD_APPLYMOVEOTHER:
             fread(&arg1, 1, 2, fileM);
@@ -4728,7 +4728,7 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
                 fsend,
                 "applymoveother 0x%X ' 0x%X Applies movement to last talked\n",
                 arg1, arg2);
-            if (arg2 != -1) DoMove(arg2);
+            if (arg2 != -1U) DoMove(arg2);
             break;
           case GLD_VERBOSEGIVEITEM:
             fread(&arg1, 1, 1, fileM);
@@ -5033,7 +5033,7 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
             arg3 = PointerToOffset((OffsetToPointer(FileZoomPos) & 0xFF) |
                                    (arg1 << 8));
             fprintf(fsend, "stringtotext 0x%X 0x%X ' 0x%X\n", arg1, arg2, arg3);
-            if (arg3 != -1) {
+            if (arg3 != -1U) {
               DoText(arg3);
             }
             break;
@@ -5044,7 +5044,7 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
             arg4 = PointerToOffset((arg1 << 8) | arg2);
             fprintf(fsend, "storetext 0x%X 0x%X 0x%X ' 0x%X\n", arg1, arg2,
                     arg3, arg4);
-            if (arg4 != -1) {
+            if (arg4 != -1U) {
               DoText(arg4);
             }
             break;
@@ -5068,7 +5068,7 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
             arg2 = PointerToOffset((OffsetToPointer(FileZoomPos) & 0xFF) |
                                    (arg1 << 8));
             fprintf(fsend, "jumptextfaceplayer 0x%X ' 0x%X\n", arg1, arg2);
-            if (arg2 != -1) DoText(arg2);
+            if (arg2 != -1U) DoText(arg2);
             still_going = 0;
             break;
           case GLD_JUMPTEXT:
@@ -5076,7 +5076,7 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
             arg2 = PointerToOffset((OffsetToPointer(FileZoomPos) & 0xFF) |
                                    (arg1 << 8));
             fprintf(fsend, "jumptext 0x%X ' 0x%X\n", arg1, arg2);
-            if (arg2 != -1) DoText(arg2);
+            if (arg2 != -1U) DoText(arg2);
             still_going = 0;
             break;
           case GLD_WINLOSSTEXT:
@@ -5088,8 +5088,8 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
                                    (arg2 << 8));
             fprintf(fsend, "winlosstext 0x%X 0x%X ' 0x%X,0x%X\n", arg1, arg2,
                     arg3, arg4);
-            if (arg3 != -1) DoText(arg3);
-            if (arg4 != -1) DoText(arg4);
+            if (arg3 != -1U) DoText(arg3);
+            if (arg4 != -1U) DoText(arg4);
             break;
           case GLD_APPEAR:
             fread(&arg1, 1, 1, fileM);
@@ -5615,7 +5615,7 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
                                    (arg2 << 8));
             fprintf(fsend, "applymovement 0x%X 0x%X ' 0x%X\n", arg1, arg2,
                     arg3);
-            if (arg3 != -1) DoMove(arg3);
+            if (arg3 != -1U) DoMove(arg3);
             break;
           case CRY_APPLYMOVEOTHER:
             fread(&arg1, 1, 2, fileM);
@@ -5625,7 +5625,7 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
                 fsend,
                 "applymoveother 0x%X ' 0x%X Applies movement to last talked\n",
                 arg1, arg2);
-            if (arg2 != -1) DoMove(arg2);
+            if (arg2 != -1U) DoMove(arg2);
             break;
           case CRY_VERBOSEGIVEITEM:
             fread(&arg1, 1, 1, fileM);
@@ -5926,7 +5926,7 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
             arg3 = PointerToOffset((OffsetToPointer(FileZoomPos) & 0xFF) |
                                    (arg1 << 8));
             fprintf(fsend, "stringtotext 0x%X 0x%X ' 0x%X\n", arg1, arg2, arg3);
-            if (arg3 != -1) {
+            if (arg3 != -1U) {
               DoText(arg3);
             }
             break;
@@ -5937,7 +5937,7 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
             arg4 = PointerToOffset((arg1 << 8) | arg2);
             fprintf(fsend, "storetext 0x%X 0x%X 0x%X ' 0x%X\n", arg1, arg2,
                     arg3, arg4);
-            if (arg4 != -1) {
+            if (arg4 != -1U) {
               DoText(arg4);
             }
             break;
@@ -5961,7 +5961,7 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
             arg2 = PointerToOffset((OffsetToPointer(FileZoomPos) & 0xFF) |
                                    (arg1 << 8));
             fprintf(fsend, "jumptextfaceplayer 0x%X ' 0x%X\n", arg1, arg2);
-            if (arg2 != -1) DoText(arg2);
+            if (arg2 != -1U) DoText(arg2);
             still_going = 0;
             break;
           case CRY_JUMPTEXT:
@@ -5969,7 +5969,7 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
             arg2 = PointerToOffset((OffsetToPointer(FileZoomPos) & 0xFF) |
                                    (arg1 << 8));
             fprintf(fsend, "jumptext 0x%X ' 0x%X\n", arg1, arg2);
-            if (arg2 != -1) DoText(arg2);
+            if (arg2 != -1U) DoText(arg2);
             still_going = 0;
             break;
           case CRY_WINLOSSTEXT:
@@ -5981,8 +5981,8 @@ void DecodeProc2(FILE* fileM_, unsigned int narc, unsigned int FileZoomPos,
                                    (arg2 << 8));
             fprintf(fsend, "winlosstext 0x%X 0x%X ' 0x%X,0x%X\n", arg1, arg2,
                     arg3, arg4);
-            if (arg3 != -1) DoText(arg3);
-            if (arg4 != -1) DoText(arg4);
+            if (arg3 != -1U) DoText(arg3);
+            if (arg4 != -1U) DoText(arg4);
             break;
           case CRY_APPEAR:
             fread(&arg1, 1, 1, fileM);

--- a/src_pksv/decompiler.h
+++ b/src_pksv/decompiler.h
@@ -7,19 +7,13 @@ void pksv_decompiler_reset(void);
 
 void DecodeProc(FILE* fileM, unsigned int narc, unsigned int FileZoomPos,
                 char* fname, FILE* fsend);
-void DecodeProcASM(FILE* fileM, unsigned int FileZoomPos, char* fname,
-                   FILE* fsend);
-void DecodeProcText(FILE* fileM, unsigned int FileZoomPos, char* fname,
-                    FILE* fsend);
-void DecodeProcPointer(FILE* fileM, unsigned int FileZoomPos, char* fname,
-                       FILE* fsend);
+void DecodeProcASM(FILE* fileM, unsigned int FileZoomPos, FILE* fsend);
+void DecodeProcText(unsigned int FileZoomPos, char* fname, FILE* fsend);
+void DecodeProcPointer(FILE* fileM, unsigned int FileZoomPos, FILE* fsend);
 void DecodeProcLevel(FILE* fileM, unsigned int FileZoomPos, char* fname,
                      FILE* fsend);
-void DecodeProcMoves(FILE* fileM, unsigned int FileZoomPos, char* fname,
-                     FILE* fsend);
-void DecodeProcMart(FILE* fileM, unsigned int FileZoomPos, char* fname,
-                    FILE* fsend);
-void DecodeProcAttacks(FILE* fileM, unsigned int FileZoomPos, char* fname,
-                       FILE* fsend);
+void DecodeProcMoves(unsigned int FileZoomPos, char* fname, FILE* fsend);
+void DecodeProcMart(FILE* fileM, unsigned int FileZoomPos, FILE* fsend);
+void DecodeProcAttacks(FILE* fileM, unsigned int FileZoomPos, FILE* fsend);
 
 #endif

--- a/src_pksv/pksv2.c
+++ b/src_pksv/pksv2.c
@@ -52,7 +52,7 @@ int main(int argc, char** argv) {
   char* export_name;
   FILE* romfile;
   FILE* otherfile;
-  unsigned int i;
+  unsigned i;
   int file_location = 0;
   uint32_t decompile_at;
   uint32_t narc;
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
   free(exename);
 
   // Argument Processing
-  for (i = 1; i < argc; i++) {
+  for (i = 1; i < (size_t)argc; i++) {
     if (argv[i][0] != '-') {
       if (file_location == 0) file_location = i;
       continue;

--- a/src_pksv/pksv_dll.c
+++ b/src_pksv/pksv_dll.c
@@ -197,7 +197,7 @@ __declspec(dllexport) __cdecl char* decompileASM(char* fname, int loc) {
 
   START_FMEM(script_file);
 
-  DecodeProcASM(romfile, loc, fname, script_file);
+  DecodeProcASM(romfile, loc, script_file);
   pksv_reset_all();
   OutputDebugString("Finished decompiling");
   fclose(romfile);
@@ -214,7 +214,7 @@ __declspec(dllexport) __cdecl char* decompileText(char* fname, int loc) {
 
   START_FMEM(script_file);
 
-  DecodeProcText(romfile, loc, fname, script_file);
+  DecodeProcText(loc, fname, script_file);
   pksv_reset_all();
   OutputDebugString("Finished decompiling");
   fclose(romfile);
@@ -248,7 +248,7 @@ __declspec(dllexport) __cdecl char* decompilePointer(char* fname, int loc) {
 
   START_FMEM(script_file);
 
-  DecodeProcPointer(romfile, loc, fname, script_file);
+  DecodeProcPointer(romfile, loc, script_file);
   pksv_reset_all();
   OutputDebugString("Finished decompiling");
   fclose(romfile);
@@ -265,7 +265,7 @@ __declspec(dllexport) __cdecl char* decompileMoves(char* fname, int loc) {
 
   START_FMEM(script_file);
 
-  DecodeProcMoves(romfile, loc, fname, script_file);
+  DecodeProcMoves(loc, fname, script_file);
   pksv_reset_all();
   OutputDebugString("Finished decompiling");
   fclose(romfile);
@@ -282,7 +282,7 @@ __declspec(dllexport) __cdecl char* decompileMart(char* fname, int loc) {
 
   START_FMEM(script_file);
 
-  DecodeProcMart(romfile, loc, fname, script_file);
+  DecodeProcMart(romfile, loc, script_file);
   pksv_reset_all();
   OutputDebugString("Finished decompiling");
   fclose(romfile);
@@ -299,7 +299,7 @@ __declspec(dllexport) __cdecl char* decompileAttacks(char* fname, int loc) {
 
   START_FMEM(script_file);
 
-  DecodeProcAttacks(romfile, loc, fname, script_file);
+  DecodeProcAttacks(romfile, loc, script_file);
   pksv_reset_all();
   OutputDebugString("Finished decompiling");
   fclose(romfile);

--- a/src_pksv/recompiler.c
+++ b/src_pksv/recompiler.c
@@ -2249,16 +2249,16 @@ void RecodeProc(char *script, char *romfn) {
               } else if (!strcmp(buf, "==0") || !strcmp(buf, "=0") ||
                          !strcmp(buf, "false")) {
                 BASIC(CRY_EQZERO);
-                arg1 = -1;
+                arg1 = -1U;
               } else if (!strcmp(buf, "!=0") || !strcmp(buf, "<>0") ||
                          !strcmp(buf, "true")) {
                 BASIC(CRY_NEQZERO);
-                arg1 = -1;
+                arg1 = -1U;
               } else {
                 log_txt("Incorrect arguments to IF\n", 29 - 1);
                 return;
               }
-              if (arg1 != -1) {
+              if (arg1 != -1U) {
                 arg1 = GetNum("IF");
                 if (!gffs) {
                   return;
@@ -2268,7 +2268,7 @@ void RecodeProc(char *script, char *romfn) {
               if (!gffs) {
                 return;
               }
-              if (arg1 != -1) rom(arg1, 1);
+              if (arg1 != -1U) rom(arg1, 1);
               rom(arg2, 2);
               ec();
             }
@@ -4401,13 +4401,13 @@ void RecodeProc(char *script, char *romfn) {
                 log_txt("Incorrect arguments to IF\n", 29 - 1);
                 return;
               }
-              if (arg1 != -1) {
+              if (arg1 != -1U) {
                 arg1 = GetNum("IF");
                 if (!gffs) {
                   return;
                 }
               }
-              if (arg1 != -1) rom(arg1, 1);
+              if (arg1 != -1U) rom(arg1, 1);
               arg2 = GetNum("IF");
               if (!gffs) {
                 return;

--- a/src_pksv/recompiler.c
+++ b/src_pksv/recompiler.c
@@ -131,7 +131,7 @@ uint32_t GetHex(const char *in, pos_int *ppos) {
 
 void try_asm_x(const char *Script, pos_int *ppos, char *buf, codeblock *c) {
   unsigned int i = *ppos;
-  int j;  // used in rom macro
+  // int j;  // used in rom macro
   register int arg1, arg2, arg3;
   ///////////////////ASM////////////////////
   if (thumb) {
@@ -1230,15 +1230,15 @@ void RecodeProc(char *script, char *romfn) {
 #endif
   char *Script;  // Whoops, used the same name for the filename.
   // Use caps-lock carefully.
-  char buf[1024], buf2[1024], buf3[1024];
+  char buf[1024], buf2[2048], buf3[1024];
   void *temp_ptr;
   int buf_loc;
   unsigned int start = 0, dynu = 0,
 #ifndef DLL
                fs,
 #endif
-               fst, i, j, k, l, arg1, arg2, arg3, arg4, arg5, arg6,
-               scriptlen;  //,arg7;
+               fst= 0, i = 0, j = 0, k = 0, l = 0, arg1 = 0, arg2 = 0, arg3 = 0, arg4 = 0, arg5 = 0, arg6 = 0,
+               scriptlen = 0;  //,arg7;
   codeblock *c = NULL;
   codeblock *d;
   codelabel *cl = NULL;

--- a/src_pksv/recompiler.c
+++ b/src_pksv/recompiler.c
@@ -132,7 +132,9 @@ uint32_t GetHex(const char *in, pos_int *ppos) {
 void try_asm_x(const char *Script, pos_int *ppos, char *buf, codeblock *c) {
   unsigned int i = *ppos;
   // int j;  // used in rom macro
-  register int arg1, arg2, arg3;
+  //note about j: it is very clearly not used, though i've left it here (commented out)
+  // just in case there's something i've missed
+  register int arg1 = 0, arg2  = 0, arg3 = 0;
   ///////////////////ASM////////////////////
   if (thumb) {
     if (!strcmp(buf, "-lsl")) {
@@ -1208,6 +1210,8 @@ struct bsearch_root *DoDefines() {
       s = "defines.dat is truncated and not fully valid\n";
     } else if (ferror(f)) {
       s = "Error reading defines.dat\n";
+    } else {
+      s = "general unknown error\n";
     }
     log_txt(s, strlen(s));
     bsearch_deinit_root(defines);  // Might not have been a valid defines.dat
@@ -1226,7 +1230,9 @@ void RecodeProc(char *script, char *romfn) {
 #endif
   FILE *IncFile = NULL, *RomFile;
 #ifdef WIN32
+#ifdef DLL
   char *strings;
+#endif
 #endif
   char *Script;  // Whoops, used the same name for the filename.
   // Use caps-lock carefully.
@@ -1240,7 +1246,7 @@ void RecodeProc(char *script, char *romfn) {
                fst= 0, i = 0, j = 0, k = 0, l = 0, arg1 = 0, arg2 = 0, arg3 = 0, arg4 = 0, arg5 = 0, arg6 = 0,
                scriptlen = 0;  //,arg7;
   codeblock *c = NULL;
-  codeblock *d;
+  codeblock *d = NULL;
   codelabel *cl = NULL;
   codelabel *cl2;
 

--- a/src_pksv/sulib.c
+++ b/src_pksv/sulib.c
@@ -170,7 +170,6 @@ void calc_org(codeblock* c, unsigned int start, char* file,
               struct bsearch_root* defines) {
   register unsigned int a;
   register codeblock* b;
-  char buf[1024];
   a = start;
   a |= 0x08000000;
   b = rewind_codeblock(c);

--- a/src_pksv/sulib.c
+++ b/src_pksv/sulib.c
@@ -170,6 +170,7 @@ void calc_org(codeblock* c, unsigned int start, char* file,
               struct bsearch_root* defines) {
   register unsigned int a;
   register codeblock* b;
+  char buf[1024];
   a = start;
   a |= 0x08000000;
   b = rewind_codeblock(c);

--- a/src_pksv/textproc.c
+++ b/src_pksv/textproc.c
@@ -442,12 +442,9 @@ char *transtxt(int howfar, const char *file, size_t word_wrap,
 }
 ////////////////////////////////////////////////////////////////////////////////////////////
 char *transbrl(int howfar, const char *file, FILE *fsend) {
-  unsigned int pt = 0;
   unsigned char p;
-  int read;
   char still_going;
   FILE *fileC;
-  read = 0;
   fileC = fopen(file, "rb");
   if (fileC != NULL) {
     fseek(fileC, (howfar & 0xffffff), SEEK_SET);
@@ -455,7 +452,6 @@ char *transbrl(int howfar, const char *file, FILE *fsend) {
     fprintf(fsend, "        '");
     while (still_going) {
       fread(&p, 1, 1, fileC);
-      pt = 0;
       if (p == 0xff) {
         still_going = 0;
         break;
@@ -475,7 +471,6 @@ char *transbrl(int howfar, const char *file, FILE *fsend) {
     still_going = 1;
     while (still_going) {
       fread(&p, 1, 1, fileC);
-      pt = 0;
       if (p == 0xff) {
         still_going = 0;
         break;
@@ -496,7 +491,6 @@ char *transbrl(int howfar, const char *file, FILE *fsend) {
     still_going = 1;
     while (still_going) {
       fread(&p, 1, 1, fileC);
-      pt = 0;
       if (p == 0xff) {
         still_going = 0;
         break;
@@ -612,7 +606,8 @@ void err_bad_hex(const char *ptr, size_t len) {
 /////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////
 char *transbackstr(char *scrfn, unsigned int pos, codeblock *c) {
-  char *NewSpace, *ret;
+  unsigned char *NewSpace;
+  char *ret;
   char cch, noend = 0;
   char str[65536];
   unsigned int i = 0, j = 0, k, l;
@@ -918,7 +913,7 @@ char *transbackstr(char *scrfn, unsigned int pos, codeblock *c) {
   }
   if (eorg) memset(NewSpace, search, j);
 
-  add_data(c, NewSpace, j);
+  add_data(c, (char*)NewSpace, j);
   free(NewSpace);
   return ret;
 }


### PR DESCRIPTION
Fix a lot of warnings throughout pksv and pksv_dll. A few still remain (notably in `gsc_moves_reverse.c`), and some related to unused parameters in the DLL functions.
Most of the warnings were related to differing signedness, typically fixed by replacing them with an unsigned literal.